### PR TITLE
fix resource mapping for mem-per-cpu

### DIFF
--- a/{{cookiecutter.profile_name}}/slurm_utils.py
+++ b/{{cookiecutter.profile_name}}/slurm_utils.py
@@ -15,7 +15,7 @@ ADJUST_TO_PARTIION = bool("{{cookiecutter.adjust_to_partition}}")
 RESOURCE_MAPPING = {
     "time": ("time", "runtime", "walltime"),
     "mem": ("mem", "mem_mb", "ram", "memory"),
-    "mem_per_cpu": ("mem_per_cpu", "mem_per_thread"),
+    "mem-per-cpu": ("mem_per_cpu", "mem_per_thread"),
 }
 
 


### PR DESCRIPTION
the slurm command for mem-per-cpu is `mem-per-cpu`, not `mem_per_cpu`